### PR TITLE
PickerViewControllerの判定構文を追加

### DIFF
--- a/DiceToolPrototype/ViewController.swift
+++ b/DiceToolPrototype/ViewController.swift
@@ -52,6 +52,9 @@ class ViewController: UIViewController, UITextFieldDelegate, UIPickerViewDelegat
   
   //UserDefaults ユーザーデフォルト　一時記憶関連
   let userDefaults = UserDefaults.standard
+	
+	private weak var frontImagePicker: UIImagePickerController?
+	private weak var backImagePicker: UIImagePickerController?
   
  
   
@@ -208,6 +211,7 @@ class ViewController: UIViewController, UITextFieldDelegate, UIPickerViewDelegat
     let frontPicker = UIImagePickerController()
     frontPicker.sourceType = sourceType
     frontPicker.delegate = self
+	frontImagePicker = frontPicker
     
     self.present(frontPicker, animated: true, completion: nil)
   
@@ -223,6 +227,7 @@ class ViewController: UIViewController, UITextFieldDelegate, UIPickerViewDelegat
     let backPicker = UIImagePickerController()
     backPicker.sourceType = sourceType
     backPicker.delegate = self
+	backImagePicker = backPicker
     
     self.present(backPicker, animated: true, completion: nil)
     
@@ -231,14 +236,24 @@ class ViewController: UIViewController, UITextFieldDelegate, UIPickerViewDelegat
   
  
   // UIImagePickerのデリゲートメソッド front
-  func imagePickerController(_ frontPicker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+  func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
     // 画像を置き換える　1[editedImage] 2[originalImage] で表示される。　ちょー重要。
     // 1のときはインスタンスの生成に frontPicker.allowsEditing = true を書き込む
     // 2のときは frontPicker.allowsEditing = true を消す
-      frontImageView.image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage
-       print("frontImageView")
+	switch picker {
+	case frontImagePicker:
+		frontImageView.image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage
+		print("frontImageView")
+		
+	case backImagePicker:
+		backImageView.image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage
+		print("backImageView")
+		
+	default:
+		break
+	}
       // 前の画面に戻る
-      self.dismiss(animated: true, completion: nil)
+      picker.dismiss(animated: true, completion: nil)
     
   }
   


### PR DESCRIPTION
根本的な問題として、Delegateパターンに対する理解がちょっと間違えたのか、足りなかったのかだと思います。

まず、 `UIImagePickerController` には、 `delegate` と言う名前のプロパティーがあります、このプロパティーは `UIImagePickerControllerDelegate` と言うプロトコルの型です（プロトコルを超正確に言うのはかなりのレベルが要求されますので、ひとまず「特殊な型」だと考えればOKです）。ソースコードの中には `frontPicker.delegate = self` や `backPicker.delegate = self` と言う構文があるのは、まさにそれぞれの `delegate` と言うプロパティーに、値を自分自身 `self` に設定する、と言う操作です。

さて、この `UIImagePickerControllerDelegate` と言う型ですが、これは `func imagePickerController(UIImagePickerController, didFinishPickingMediaWithInfo: [UIImagePickerController.InfoKey : Any])` と言うメソッド（デリゲートメソッド）を持ちます、このメソッドを自分で実装することによって、このメソッドが呼ばれた時の動作が実行されます。

ところで、元のプログラムでは `backPicker` の場合 `func backImagePickerController(UIImagePickerController, didFinishPickingMediaWithInfo: [UIImagePickerController.InfoKey : Any])` の方で動作を実装しましたが、残念ながらそもそも `UIImagePickerControllerDelegate` にはこのメソッドがありません、すなわちそもそもこのメソッドが呼ばれることは残念ながらありません

ではどのように組み込めばいいかと言うと、デリゲートメソッドでは呼び出し元である `UIImagePickerController` を `picker` として引数に渡しているので、この `picker` を見て誰からの呼び出しなのかを判断すればいいのです